### PR TITLE
fix: scalar loading conditionals

### DIFF
--- a/lib/scalars/json.ex
+++ b/lib/scalars/json.ex
@@ -1,4 +1,13 @@
-if :ecto in Mix.Project.deps_apps() do
+is_jason_loaded =
+  try do
+    Code.ensure_compiled!(Jason)
+    true
+  rescue
+    _ ->
+      false
+  end
+
+if is_jason_loaded do
   defmodule AbsintheUtils.Scalars.JSON do
     @moduledoc """
     The JSON scalar type allows arbitrary JSON values to be passed in and out.

--- a/lib/scalars/json.ex
+++ b/lib/scalars/json.ex
@@ -1,60 +1,56 @@
-case Code.ensure_loaded(Jason) do
-  {:module, _} ->
-    defmodule AbsintheUtils.Scalars.JSON do
-      @moduledoc """
-      The JSON scalar type allows arbitrary JSON values to be passed in and out.
-      Requires `{ :jason, ">= 1.1" }` package: https://github.com/michalmuskala/jason
+if :ecto in Mix.Project.deps_apps() do
+  defmodule AbsintheUtils.Scalars.JSON do
+    @moduledoc """
+    The JSON scalar type allows arbitrary JSON values to be passed in and out.
+    Requires `{ :jason, ">= 1.1" }` package: https://github.com/michalmuskala/jason
 
-      Based in the
-      [recipes on Absinthe's wiki](https://github.com/absinthe-graphql/absinthe/wiki/Scalar-Recipes)
+    Based in the
+    [recipes on Absinthe's wiki](https://github.com/absinthe-graphql/absinthe/wiki/Scalar-Recipes)
 
-      Note that even if you use `non_null(:json)` a string of null value (`"null"`) is still accepted.
+    Note that even if you use `non_null(:json)` a string of null value (`"null"`) is still accepted.
 
-      **Usage:**
+    **Usage:**
 
-      Import the type in your schema `import_types(AbsintheUtils.Scalars.JSON)` and you will be able
-      to use the `:json` type.
-      """
-      use Absinthe.Schema.Notation
+    Import the type in your schema `import_types(AbsintheUtils.Scalars.JSON)` and you will be able
+    to use the `:json` type.
+    """
+    use Absinthe.Schema.Notation
 
-      scalar :json, name: "JSON" do
-        description("""
-        The `JSON` scalar type represents arbitrary JSON string data, represented as UTF-8
-        character sequences. The JSON type is most often used to represent a free-form
-        human-readable json string.
-        """)
+    scalar :json, name: "JSON" do
+      description("""
+      The `JSON` scalar type represents arbitrary JSON string data, represented as UTF-8
+      character sequences. The JSON type is most often used to represent a free-form
+      human-readable json string.
+      """)
 
-        serialize(&encode/1)
-        parse(&decode/1)
-      end
+      serialize(&encode/1)
+      parse(&decode/1)
+    end
 
-      @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, term()} | :error
-      @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
-      defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
-        case Jason.decode(value) do
-          {:ok, result} -> {:ok, result}
-          _ -> :error
-        end
-      end
-
-      defp decode(%Absinthe.Blueprint.Input.Null{}) do
-        {:ok, nil}
-      end
-
-      defp decode(_), do: :error
-
-      defp encode(value) do
-        case Jason.encode(value) do
-          {:ok, _} ->
-            value
-
-          {:error, _} ->
-            raise Absinthe.SerializationError,
-                  "Could not serialize term #{inspect(value)} as type UUID."
-        end
+    @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, term()} | :error
+    @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+    defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
+      case Jason.decode(value) do
+        {:ok, result} -> {:ok, result}
+        _ -> :error
       end
     end
 
-  _ ->
-    nil
+    defp decode(%Absinthe.Blueprint.Input.Null{}) do
+      {:ok, nil}
+    end
+
+    defp decode(_), do: :error
+
+    defp encode(value) do
+      case Jason.encode(value) do
+        {:ok, _} ->
+          value
+
+        {:error, _} ->
+          raise Absinthe.SerializationError,
+                "Could not serialize term #{inspect(value)} as type UUID."
+      end
+    end
+  end
 end

--- a/lib/scalars/json.ex
+++ b/lib/scalars/json.ex
@@ -1,12 +1,12 @@
 is_jason_loaded =
   try do
-    if function_exported?(Code, :ensure_compiled, 1) do
+    if function_exported?(Code, :ensure_compiled!, 1) do
       Code.ensure_compiled!(Jason)
-      true
     else
       {:module, _module} = Code.ensure_compiled(Jason)
-      true
     end
+
+    true
   rescue
     _ ->
       false

--- a/lib/scalars/json.ex
+++ b/lib/scalars/json.ex
@@ -1,7 +1,12 @@
 is_jason_loaded =
   try do
-    Code.ensure_compiled!(Jason)
-    true
+    if function_exported?(Code, :ensure_compiled, 1) do
+      Code.ensure_compiled!(Jason)
+      true
+    else
+      {:module, _module} = Code.ensure_compiled(Jason)
+      true
+    end
   rescue
     _ ->
       false

--- a/lib/scalars/uuid.ex
+++ b/lib/scalars/uuid.ex
@@ -1,12 +1,12 @@
 is_ecto_loaded =
   try do
-    if function_exported?(Code, :ensure_compiled, 1) do
+    if function_exported?(Code, :ensure_compiled!, 1) do
       Code.ensure_compiled!(Ecto.UUID)
-      true
     else
       {:module, _module} = Code.ensure_compiled(Ecto.UUID)
-      true
     end
+
+    true
   rescue
     _ ->
       false

--- a/lib/scalars/uuid.ex
+++ b/lib/scalars/uuid.ex
@@ -1,57 +1,53 @@
-case Code.ensure_loaded(Ecto.UUID) do
-  {:module, _} ->
-    defmodule AbsintheUtils.Scalars.UUID do
-      @moduledoc """
-      The UUID scalar type allows UUID compliant strings to be passed in and out.
-      Requires `{ :ecto, ">= 0.0.0" }` package: https://github.com/elixir-ecto/ecto
+if :jason in Mix.Project.deps_apps() do
+  defmodule AbsintheUtils.Scalars.UUID do
+    @moduledoc """
+    The UUID scalar type allows UUID compliant strings to be passed in and out.
+    Requires `{ :ecto, ">= 0.0.0" }` package: https://github.com/elixir-ecto/ecto
 
-      Based in the
-      [recipes on Absinthe's wiki](https://github.com/absinthe-graphql/absinthe/wiki/Scalar-Recipes)
+    Based in the
+    [recipes on Absinthe's wiki](https://github.com/absinthe-graphql/absinthe/wiki/Scalar-Recipes)
 
-      **Usage:**
+    **Usage:**
 
-      Import the type in your schema `import_types(AbsintheUtils.Scalars.JSON)` and you will be able
-      to use the `:json` type.
-      """
-      use Absinthe.Schema.Notation
+    Import the type in your schema `import_types(AbsintheUtils.Scalars.JSON)` and you will be able
+    to use the `:json` type.
+    """
+    use Absinthe.Schema.Notation
 
-      alias Ecto.UUID
+    alias Ecto.UUID
 
-      scalar :uuid, name: "UUID" do
-        description("""
-        The `UUID` scalar type represents UUID compliant string data, represented as UTF-8
-        character sequences. The UUID type is most often used to represent unique
-        machine-readable ID strings.
-        """)
+    scalar :uuid, name: "UUID" do
+      description("""
+      The `UUID` scalar type represents UUID compliant string data, represented as UTF-8
+      character sequences. The UUID type is most often used to represent unique
+      machine-readable ID strings.
+      """)
 
-        serialize(&encode/1)
-        parse(&decode/1)
-      end
-
-      @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, term()} | :error
-      @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
-      defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
-        UUID.cast(value)
-      end
-
-      defp decode(%Absinthe.Blueprint.Input.Null{}) do
-        {:ok, nil}
-      end
-
-      defp decode(_), do: :error
-
-      defp encode(value) do
-        case UUID.cast(value) do
-          :error ->
-            raise Absinthe.SerializationError,
-                  "Could not serialize term #{inspect(value)} as type UUID."
-
-          {:ok, uuid} ->
-            uuid
-        end
-      end
+      serialize(&encode/1)
+      parse(&decode/1)
     end
 
-  _ ->
-    nil
+    @spec decode(Absinthe.Blueprint.Input.String.t()) :: {:ok, term()} | :error
+    @spec decode(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+    defp decode(%Absinthe.Blueprint.Input.String{value: value}) do
+      UUID.cast(value)
+    end
+
+    defp decode(%Absinthe.Blueprint.Input.Null{}) do
+      {:ok, nil}
+    end
+
+    defp decode(_), do: :error
+
+    defp encode(value) do
+      case UUID.cast(value) do
+        :error ->
+          raise Absinthe.SerializationError,
+                "Could not serialize term #{inspect(value)} as type UUID."
+
+        {:ok, uuid} ->
+          uuid
+      end
+    end
+  end
 end

--- a/lib/scalars/uuid.ex
+++ b/lib/scalars/uuid.ex
@@ -1,7 +1,12 @@
 is_ecto_loaded =
   try do
-    Code.ensure_compiled!(Ecto.UUID)
-    true
+    if function_exported?(Code, :ensure_compiled, 1) do
+      Code.ensure_compiled!(Ecto.UUID)
+      true
+    else
+      {:module, _module} = Code.ensure_compiled(Ecto.UUID)
+      true
+    end
   rescue
     _ ->
       false

--- a/lib/scalars/uuid.ex
+++ b/lib/scalars/uuid.ex
@@ -1,4 +1,13 @@
-if :jason in Mix.Project.deps_apps() do
+is_ecto_loaded =
+  try do
+    Code.ensure_compiled!(Ecto.UUID)
+    true
+  rescue
+    _ ->
+      false
+  end
+
+if is_ecto_loaded do
   defmodule AbsintheUtils.Scalars.UUID do
     @moduledoc """
     The UUID scalar type allows UUID compliant strings to be passed in and out.


### PR DESCRIPTION
Changed to check if the peer dependencies are in the Mix Deps instead of checking for module availability:

`Mix.Project.deps_apps()`