### PR TITLE
removed scalar conditionals as it yields unpredictable results

### DIFF
--- a/.github/workflows/test-and-publish.yaml
+++ b/.github/workflows/test-and-publish.yaml
@@ -14,5 +14,7 @@ jobs:
   test-and-publish:
     name: Test and publish
     uses: significa/actions/.github/workflows/elixir-library.yaml@main
+    with:
+      mix-compile-opts: ""
     secrets:
       HEX_API_KEY: ${{ secrets.HEX_API_KEY }}

--- a/lib/scalars/json.ex
+++ b/lib/scalars/json.ex
@@ -1,18 +1,4 @@
-is_jason_loaded =
-  try do
-    if function_exported?(Code, :ensure_compiled!, 1) do
-      Code.ensure_compiled!(Jason)
-    else
-      {:module, _module} = Code.ensure_compiled(Jason)
-    end
-
-    true
-  rescue
-    _ ->
-      false
-  end
-
-if is_jason_loaded do
+if Application.get_env(:absinthe_utils, :compile_json_scalar, true) do
   defmodule AbsintheUtils.Scalars.JSON do
     @moduledoc """
     The JSON scalar type allows arbitrary JSON values to be passed in and out.

--- a/lib/scalars/uuid.ex
+++ b/lib/scalars/uuid.ex
@@ -1,18 +1,4 @@
-is_ecto_loaded =
-  try do
-    if function_exported?(Code, :ensure_compiled!, 1) do
-      Code.ensure_compiled!(Ecto.UUID)
-    else
-      {:module, _module} = Code.ensure_compiled(Ecto.UUID)
-    end
-
-    true
-  rescue
-    _ ->
-      false
-  end
-
-if is_ecto_loaded do
+if Application.get_env(:absinthe_utils, :compile_uuid_scalar, true) do
   defmodule AbsintheUtils.Scalars.UUID do
     @moduledoc """
     The UUID scalar type allows UUID compliant strings to be passed in and out.


### PR DESCRIPTION
The disadvantage is that this might cause a warning to be printed during compilation. To avoid it set ` :compile_json_scalar` or `:compile_uuid_scalar` in the `:absinthe_utils` Application.