### PR TITLE
Strict Naive DateTime

### DIFF
--- a/.credo.exs
+++ b/.credo.exs
@@ -84,12 +84,6 @@
           #
           {Credo.Check.Design.AliasUsage,
            [priority: :low, if_nested_deeper_than: 2, if_called_more_often_than: 0]},
-          # You can also customize the exit_status of each check.
-          # If you don't want TODO comments to cause `mix credo` to fail, just
-          # set this value to 0 (zero).
-          #
-          {Credo.Check.Design.TagTODO, [exit_status: 2]},
-          {Credo.Check.Design.TagFIXME, []},
 
           #
           ## Readability Checks
@@ -161,6 +155,13 @@
         disabled: [
           #
           # Checks scheduled for next check update (opt-in for now, just replace `false` with `[]`)
+
+          # You can also customize the exit_status of each check.
+          # If you don't want TODO comments to cause `mix credo` to fail, just
+          # set this value to 0 (zero).
+          #
+          {Credo.Check.Design.TagTODO, [exit_status: 2]},
+          {Credo.Check.Design.TagFIXME, []},
 
           #
           # Controversial and experimental checks (opt-in, just move the check to `:enabled`

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Documentation can be found in [HexDocs].
   arguments (`arg`).
 - `AbsintheUtils.Scalars.JSON`: JSON scalar.
 - `AbsintheUtils.Scalars.UUID`: UUID scalar.
+- `AbsintheUtils.Scalars.StrictNaiveDateTime`: NaiveDatetime that does not accept ISO8601 with offset.
 
 [hexpm]: https://hex.pm/packages/absinthe_utils
 [hexdocs]: https://hexdocs.pm/absinthe_utils

--- a/lib/scalars/strict_naive_datetime.ex
+++ b/lib/scalars/strict_naive_datetime.ex
@@ -1,0 +1,71 @@
+defmodule AbsintheUtils.Scalars.StrictNaiveDateTime do
+  @description """
+  The `StrictNaiveDateTime` scalar type represents a naive date and time without
+  timezone.
+  The output is an ISO8601 formatted string.
+  The input must be a naive datetime, without timezone offset.
+
+  Valid examples:
+  - 2020-01-01T00:00:00
+  - 2020-01-01 00:00:00
+
+  Invalid examples:
+  - 2020-01-01T00:00:00+00:00
+  - 2020-01-01T00:00:00+01:00
+  - 2020-01-01T00:00:00Z
+  - 2020-01-01 00:00:00Z
+  """
+
+  @moduledoc """
+  #{@description}
+
+  Based on the type `naive_datetime` from `Absinthe.Type.Custom`.
+  """
+
+  use Absinthe.Schema.Notation
+
+  scalar :strict_naive_datetime, name: "StrictNaiveDateTime" do
+    description(@description)
+
+    parse(&parse_naive_datetime/1)
+
+    serialize(fn value ->
+      case value do
+        %NaiveDateTime{} -> NaiveDateTime.to_iso8601(value)
+        _ -> raise Absinthe.SerializationError, "Invalid naive datetime value"
+      end
+    end)
+  end
+
+  @spec parse_naive_datetime(Absinthe.Blueprint.Input.String.t()) ::
+          {:ok, NaiveDateTime.t()} | :error
+  @spec parse_naive_datetime(Absinthe.Blueprint.Input.Null.t()) :: {:ok, nil}
+  defp parse_naive_datetime(%Absinthe.Blueprint.Input.String{value: value}) do
+    case DateTime.from_iso8601(value) do
+      {:error, :missing_offset} ->
+        case NaiveDateTime.from_iso8601(value) do
+          {:ok, naive_datetime} -> {:ok, naive_datetime}
+          _error -> {:error, "Invalid ISO8601 datetime"}
+        end
+
+      {:ok, _datetime, offset} when not is_nil(offset) ->
+        {
+          :error,
+          "Invalid ISO8601 datetime without timezone offset. Received an offset of #{offset}, expected no offset. " <>
+            "Example: 2020-01-01T00:00:00 instead of 2020-01-01T00:00:00Z. " <>
+            "For more information refer to the GraphQL description of this field type."
+        }
+
+      _ ->
+        {:error, "Invalid ISO8601 datetime without timezone offset"}
+    end
+  end
+
+  defp parse_naive_datetime(%Absinthe.Blueprint.Input.Null{}) do
+    {:ok, nil}
+  end
+
+  defp parse_naive_datetime(_) do
+    :error
+  end
+end

--- a/test/scalars/strict_naive_datetime_test.exs
+++ b/test/scalars/strict_naive_datetime_test.exs
@@ -1,0 +1,136 @@
+defmodule AbsintheUtilsTest.Scalars.StrictNaiveDateTimeTest do
+  use ExUnit.Case, async: true
+
+  @sample_naive_datetime_string "2020-01-01T00:00:00"
+
+  defmodule TestSchema do
+    use Absinthe.Schema
+
+    import_types(AbsintheUtils.Scalars.StrictNaiveDateTime)
+
+    @sample_naive_datetime ~N[2020-01-01 00:00:00]
+
+    query do
+      field :query_with_naive_date_time_argument, :strict_naive_datetime do
+        arg(:naive_date_time, :strict_naive_datetime)
+
+        resolve(fn _, params, _ ->
+          {:ok, Map.get(params, :naive_date_time)}
+        end)
+      end
+
+      field :query_returning_naive_date_time, :strict_naive_datetime do
+        resolve(fn _, _, _ ->
+          {:ok, @sample_naive_datetime}
+        end)
+      end
+
+      field :query_returning_invalid_naive_date_time, :strict_naive_datetime do
+        resolve(fn _, _, _ ->
+          {:ok, "invalid_strict_naive_datetime"}
+        end)
+      end
+    end
+  end
+
+  describe "input" do
+    @query """
+      query (
+        $naiveDateTime: StrictNaiveDateTime
+      ) {
+        queryWithNaiveDateTimeArgument (
+         naiveDateTime: $naiveDateTime
+        )
+      }
+    """
+
+    test "valid naive datetime" do
+      assert {:ok,
+              %{
+                data: %{
+                  "queryWithNaiveDateTimeArgument" => @sample_naive_datetime_string
+                }
+              }} ===
+               Absinthe.run(
+                 @query,
+                 TestSchema,
+                 variables: %{
+                   "naiveDateTime" => @sample_naive_datetime_string
+                 }
+               )
+    end
+
+    test "invalid naive datetime" do
+      assert {:ok,
+              %{
+                errors: [
+                  %{
+                    message:
+                      "Argument \"naiveDateTime\" has invalid value $naiveDateTime.\nInvalid ISO8601 datetime without timezone offset"
+                  }
+                ]
+              }} =
+               Absinthe.run(
+                 @query,
+                 TestSchema,
+                 variables: %{
+                   "naiveDateTime" => "invalid_naive_datetime"
+                 }
+               )
+    end
+
+    test "invalid passing a datetime with offset" do
+      assert {:ok,
+              %{
+                errors: [
+                  %{
+                    message:
+                      "Argument \"naiveDateTime\" has invalid value $naiveDateTime.\nInvalid ISO8601" <>
+                        " datetime without timezone offset. Received an offset of 0, expected no offset." <>
+                        " Example: 2020-01-01T00:00:00 instead of 2020-01-01T00:00:00Z." <>
+                        " For more information refer to the GraphQL description of this field type."
+                  }
+                ]
+              }} =
+               Absinthe.run(
+                 @query,
+                 TestSchema,
+                 variables: %{
+                   "naiveDateTime" => "2020-01-01T00:00:00+00:00"
+                 }
+               )
+    end
+  end
+
+  describe "output" do
+    test "valid naive datetime" do
+      assert {:ok,
+              %{
+                data: %{
+                  "queryReturningNaiveDateTime" => @sample_naive_datetime_string
+                }
+              }} ===
+               Absinthe.run(
+                 """
+                   query {
+                     queryReturningNaiveDateTime
+                   }
+                 """,
+                 TestSchema
+               )
+    end
+
+    test "invalid naive datetime" do
+      assert_raise Absinthe.SerializationError, fn ->
+        Absinthe.run(
+          """
+            query {
+              queryReturningInvalidNaiveDateTime
+            }
+          """,
+          TestSchema
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Basically a naive datetime that errors when the input is not a naive datetime - forces clientes to understand what is going on